### PR TITLE
DS-4122 - Update composer.json file to be able to use asset-packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
         }
     ],
     "scripts": {
@@ -30,6 +34,10 @@
       ]
     },
     "extra": {
+        "installer-types": [
+            "bower-asset",
+            "npm-asset"
+        ],
         "installer-paths": {
             "html/core": [
                 "drupal/core"
@@ -45,6 +53,11 @@
             ],
             "html/themes/contrib/{$name}": [
                 "type:drupal-theme"
+            ],
+            "html/libraries/{$name}": [
+                "type:drupal-library",
+                "type:bower-asset",
+                "type:npm-asset"
             ],
             "drush/contrib/{$name}": [
                 "type:drupal-drush"


### PR DESCRIPTION
## Description

We're moving the front-end libraries to the composer.json file as dependencies. This requires an update for the composer.json file.

In a next release we will actually make use of the changes we make here.

## How to test

- [ ] Simply run `composer update` and `composer install`, both should still work fine