### PR TITLE
Use https version to avoid ssh problem when cloning packages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -244,7 +244,7 @@
             "version": "0.5.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:oesmith/morris.js.git",
+                "url": "https://github.com/oesmith/morris.js.git",
                 "reference": "d5cf1410eda7055eaf2c7d218d4cb24ec5ed55c8"
             },
             "dist": {
@@ -287,7 +287,7 @@
             "version": "4.0.5",
             "source": {
                 "type": "git",
-                "url": "git@github.com:ivaynberg/select2.git",
+                "url": "https://github.com/ivaynberg/select2.git",
                 "reference": "ebf10c93db7d6d7a0d1330119d4c6f32cbd231d7"
             },
             "dist": {


### PR DESCRIPTION
When run ```composer create-project goalgorilla/social_template:dev-master DIRECTORY --no-interaction```

I get on 2 packages cloned from github this error:
Error: Permission denied (publickey)

I saw that in genral this package use the https version of the package to install them.
Also select2 and morris should use the https version to avoid this kind of problems.

An approach to solve this in general would be configuring the local environement with:

```composer config --global github-protocols https ```

And after that, a "composer install" will generate a composer.lock with https in all the packages.
Would be good commit in this repo this generated composer.lock in order to avoid the error i get.

If this solution is not ok for who want to install this package and still get error there is a wrokaround that split in several commands the `composer create-project`

```
git clone https://github.com/goalgorilla/social_template.git
composer config --global github-protocols https
composer install
```
  