### PR TITLE
Bump minimum PHP version to 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,7 @@
         "drupal-composer/drupal-scaffold": "^2.6.1",
         "cweagans/composer-patches": "^1.0",
         "goalgorilla/open_social": "^7.0",
-        "doctrine/cache": "1.6.1",
-        "doctrine/collections": "1.4.0",
-        "doctrine/common": "2.7.2",
-        "php": "^5.6 || ^7.0",
-        "doctrine/inflector": "1.1.0",
-        "doctrine/lexer": "1.0.2",
+        "php": "^7.2",
         "monolog/monolog": "^1.17"
     },
     "repositories": [


### PR DESCRIPTION
PHP versions lower than 7.2 are no longer supported so it's safe to remove this constraint from our project template.

This also allows the fixed doctrine versions to be removed to ensure we don't accidentally get old versions of packages.