### PR TITLE
Add patchLevel -p2 to drupal/core in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
                 "type:drupal-drush"
             ]
         },
-        "enable-patching": true
+        "enable-patching": true,
+        "patchLevel": {
+            "drupal/core": "-p2"
+        }
     }
 }


### PR DESCRIPTION
### Problem
Patches in core are not always correctly applied. 

### Solution
Add patchLevel -p2 to drupal/core in composer.json, this should help with patches applying.